### PR TITLE
feat(helm): mount build-task-consumer API key as a file

### DIFF
--- a/helm-templates/qubership-apihub/templates/qubership-apihub-build-task-consumer-deployment.yaml
+++ b/helm-templates/qubership-apihub/templates/qubership-apihub-build-task-consumer-deployment.yaml
@@ -28,9 +28,18 @@ spec:
                 app.kubernetes.io/technology: 'node-js'
         spec:
             serviceAccountName: 'qubership-apihub-build-task-consumer'
+            volumes:
+            -   name: apihub-api-key
+                secret:
+                    defaultMode: 420
+                    secretName: 'qubership-apihub-build-task-consumer-api-key-secret'
             containers:
             -   name: 'qubership-apihub-build-task-consumer'
                 image: '{{ .Values.qubershipApihubBuildTaskConsumer.image.repository }}:{{ .Values.qubershipApihubBuildTaskConsumer.image.tag }}'
+                volumeMounts:
+                -   name: apihub-api-key
+                    mountPath: /etc/secrets/apihub
+                    readOnly: true
                 ports:
                 -   name: web
                     containerPort: 3000
@@ -44,11 +53,8 @@ spec:
                     value: '/tmp' 
                 -   name: OPERATIONS_BUILD_BATCH
                     value: '{{ .Values.qubershipApihubBuildTaskConsumer.env.operationsBuildBatch }}'
-                -   name: APIHUB_API_KEY
-                    valueFrom:
-                        secretKeyRef:
-                            name: 'qubership-apihub-build-task-consumer-api-key-secret'
-                            key: access_token
+                -   name: APIHUB_API_KEY_FILE
+                    value: '/etc/secrets/apihub/access_token'
                 resources:
                     requests:
                         cpu: {{ .Values.qubershipApihubBuildTaskConsumer.resource.cpu.request }}


### PR DESCRIPTION
## Summary
- Mount `qubership-apihub-build-task-consumer-api-key-secret` as a volume at `/etc/secrets/apihub`
- Replace `APIHUB_API_KEY` env injection with `APIHUB_API_KEY_FILE=/etc/secrets/apihub/access_token`

Depends on the matching change in `qubership-apihub-build-task-consumer` that reads the key from a file.

## Test plan
- [ ] Helm template/render and verify volume, volumeMount, and `APIHUB_API_KEY_FILE` env
- [ ] Deploy to kind/cluster and confirm the file `/etc/secrets/apihub/access_token` exists in the pod
- [ ] Confirm build-task-consumer can poll/authenticate against the backend after deploy

Made with [Cursor](https://cursor.com)