### PR TITLE
feat: update E2E test workflow to include both Portal and Agent projects in default arguments

### DIFF
--- a/.github/workflows/run-e2e-tests-kind.yml
+++ b/.github/workflows/run-e2e-tests-kind.yml
@@ -30,7 +30,7 @@ on:
       playwright-test-args:
         description: "Playwright test command CLI arguments"
         type: string
-        default: "--project=Portal --workers=8 --grep-invert=@flaky"
+        default: "--project=Portal --project=Agent --workers=8 --grep-invert=@flaky"
       image-tags:
         description: "JSON object with backend, buildTaskConsumer, ui, apiLinterService, agentsBackend, and agent tags"
         type: string

--- a/.github/workflows/run-e2e-tests-kind.yml
+++ b/.github/workflows/run-e2e-tests-kind.yml
@@ -30,7 +30,7 @@ on:
       playwright-test-args:
         description: "Playwright test command CLI arguments"
         type: string
-        default: "--project=Portal --project=Agent --workers=8 --grep-invert=@flaky"
+        default: "--project=Portal --project=Agent --workers=8 --grep-invert='@flaky|@specific'"
       image-tags:
         description: "JSON object with backend, buildTaskConsumer, ui, apiLinterService, agentsBackend, and agent tags"
         type: string


### PR DESCRIPTION
## Summary

- Extend default `playwright-test-args` in the Kind E2E workflow (`run-e2e-tests-kind.yml`) to include both `--project=Portal` and `--project=Agent`.
- Align Playwright defaults with the existing Kind setup: Agent deployment is enabled by default (`apihub-agent-run: true`) and Agent Postman smoke tests are already in the default collections list.

## Motivation

Previously, manual Kind E2E runs executed only the Portal Playwright project unless the caller overrode `playwright-test-args`. Agent UI coverage was skipped despite the Agent stack being deployed.

## Changes

- `.github/workflows/run-e2e-tests-kind.yml`: update `playwright-test-args` default from `--project=Portal --workers=8 --grep-invert=@flaky` to `--project=Portal --project=Agent --workers=8 --grep-invert=@flaky`.

## Successful CI run

https://github.com/Netcracker/qubership-apihub/actions/runs/32241710912

## How to verify

After merge https://github.com/Netcracker/qubership-apihub-ui-tests/pull/102 and https://github.com/Netcracker/qubership-apihub-ci/pull/73

1. Trigger **Manual Run E2E Tests in Kind Workflow** with default inputs.
2. Confirm Playwright runs both Portal and Agent projects.
3. Verify the workflow completes successfully with `apihub-agent-run: true`.